### PR TITLE
For existing users, revoke policies when none is selected and other minor issues - 34

### DIFF
--- a/classes/event/acceptance_base.php
+++ b/classes/event/acceptance_base.php
@@ -29,7 +29,7 @@ use core\event\base;
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Base class for acceptance_created and acceptance_updated events
+ * Base class for acceptance_created and acceptance_updated events.
  *
  * @package     tool_policy
  * @copyright   2018 Marina Glancy
@@ -67,7 +67,7 @@ abstract class acceptance_base extends base {
     }
 
     /**
-     * Get URL related to the action
+     * Get URL related to the action.
      *
      * @return \moodle_url
      */

--- a/index.php
+++ b/index.php
@@ -35,6 +35,7 @@ define('NO_SITEPOLICY_CHECK', true);
 // @codingStandardsIgnoreLine See the {@link page_agreedocs} for the access control checks.
 require(__DIR__.'/../../../config.php');
 
+$action = optional_param('action', null, PARAM_ALPHA);
 $agreedocs = optional_param_array('agreedoc', null, PARAM_INT);
 $behalfid = optional_param('userid', null, PARAM_INT);
 
@@ -59,7 +60,7 @@ if (!empty($USER->id)) {
 if (!$haspermissionagreedocs) {
     $outputpage = new \tool_policy\output\page_nopermission($behalfid);
 } else {
-    $outputpage = new \tool_policy\output\page_agreedocs($agreedocs, $behalfid);
+    $outputpage = new \tool_policy\output\page_agreedocs($agreedocs, $behalfid, $action);
 }
 
 $output = $PAGE->get_renderer('tool_policy');

--- a/templates/guestconsent.mustache
+++ b/templates/guestconsent.mustache
@@ -29,6 +29,7 @@
     Context variables required for this template:
     * pluginbaseurl
     * returnurl - urlencoded URL to return to
+    * haspolicies - true if there are guest policies; false otherwise
     * policies - array of policy documents
 
     Example context (json):

--- a/templates/page_agreedocs.mustache
+++ b/templates/page_agreedocs.mustache
@@ -58,6 +58,7 @@
 
 <form id="agreedocsform" method="post" action="{{myurl}}">
     <input type="hidden" name="sesskey" value="{{sesskey}}">
+    <input type="hidden" name="action" value="agreedocs">
 
 {{#behalfuser}}
 <div class="clearfix">


### PR DESCRIPTION
- For existing users, revoke policies when none is selected
- Display warning message ("Before continuing you must agree to all these policies.") for existing users when no policy is selected and the next button is pressed.
- Add missing variable declaration in guestconsent.mustache
- Add missing missing dots in acceptance_base