### PR TITLE
Remove presignup session when user is signed up

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -879,6 +879,11 @@ class api {
         if (!$user->policyagreed) {
             return;
         }
+        // Remove the presignup cache after the user account is created.
+        $cache = \cache::make('core', 'presignup');
+        $cache->delete('tool_policy_userpolicyagreed');
+        $cache->delete('tool_policy_viewedpolicies');
+
         // Get all active policies.
         $currentpolicyversions = static::get_current_versions_ids(policy_version::AUDIENCE_LOGGEDIN);
         // Save active policies as accepted by the user.

--- a/classes/output/page_agreedocs.php
+++ b/classes/output/page_agreedocs.php
@@ -170,10 +170,10 @@ class page_agreedocs implements renderable, templatable {
                 // If the user has accepted all the policies, add it to the session to let continue with the signup process.
                 $this->signupuserpolicyagreed = empty(array_diff($currentpolicyversionids, $this->agreedocs));
                 \cache::make('core', 'presignup')->set('tool_policy_userpolicyagreed',
-                    $this->agreedocs);
+                    $this->signupuserpolicyagreed);
             } else if (empty($this->policies)) {
                 // There are no policies to agree to. Update the policyagreed value to avoid show empty consent page.
-                \cache::make('core', 'presignup')->set('tool_policy_userpolicyagreed', []);
+                \cache::make('core', 'presignup')->set('tool_policy_userpolicyagreed', 1);
             }
             if (!empty($this->policies) && !$this->signupuserpolicyagreed) {
                 // During the signup process, inform users they must agree to all policies before continuing.


### PR DESCRIPTION
After the user is signed up, the presignup session should be deleted to avoid bypassing of the policy acceptance page when creating another account while the session is still active and has data.