### PR TITLE
Workaround for fixing behat tests issue with selenium - 34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-sudo: false
+# Workaround for fixing that Selenium server is not running and therefore javascript Behat tests are not working:
+# https://github.com/moodlerooms/moodle-plugin-ci/issues/70
+sudo: required
+# ORIGINAL:
+# sudo: false
 
 addons:
   firefox: "47.0.1"


### PR DESCRIPTION
As explained in https://github.com/moodlerooms/moodle-plugin-ci/issues/70,
selenium server is not running due to some issue when "sudo: false" and,
therefore, @javascript behat tests are not working.