### PR TITLE
Fix UI indication of an active policy version

### DIFF
--- a/templates/acceptances.mustache
+++ b/templates/acceptances.mustache
@@ -100,7 +100,7 @@
                     </td>
                     <td>
                         <a href="{{viewurl}}">{{{revision}}}</a>
-                        {{#iscurrent}}{{#pix}} t/check, core {{/pix}}{{/iscurrent}}
+                        {{#iscurrent}}<span class="label label-success">{{#str}} status1, tool_policy {{/str}}{{/iscurrent}}
                     </td>
                     <td>
                         {{#agreement}}


### PR DESCRIPTION
As reported by Barbara:

> Following the discussion Al and I had yesterday, there are 3 things that need to be changed on the Policies and agreements flow and UI
> First, is to change the tick right next to the active policy to a pill with text Active

This patch changes the tick.