### PR TITLE
MDL-61844 policy: Avoid to accept new policies during current session - 34

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -477,7 +477,7 @@ class api {
      * @param int $versionid
      */
     public static function make_current($versionid) {
-        global $DB;
+        global $DB, $USER;
 
         $policyversion = new policy_version($versionid);
         if (! $policyversion->get('id') || $policyversion->get('archived')) {
@@ -498,6 +498,11 @@ class api {
 
         // Reset the policyagreed flag to force everybody re-accept the policies.
         $DB->set_field('user', 'policyagreed', 0);
+
+        // Make sure that the current user is not immediately redirected to the policy acceptance page.
+        if (isloggedin() && !isguestuser()) {
+            $USER->policyagreed = 1;
+        }
     }
 
     /**

--- a/classes/output/page_agreedocs.php
+++ b/classes/output/page_agreedocs.php
@@ -144,14 +144,7 @@ class page_agreedocs implements renderable, templatable {
                     ];
                 }
                 $this->messages[] = $message;
-            } else if (empty($this->policies)) {
-                // There are no policies to agree to. Update the policyagreed value to avoid display empty consent page.
-                $currentuser = (!empty($this->behalfuser)) ? $this->behalfuser : $USER;
-                // Check for updating when the user policyagreed is false.
-                if (!$currentuser->policyagreed) {
-                    api::update_policyagreed($currentuser);
-                }
-            } else if (empty($USER->policyagreed)) {
+            } else if (!empty($this->policies) && empty($USER->policyagreed)) {
                 // Inform users they must agree to all policies before continuing.
                 $message = (object) [
                     'type' => 'error',

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -551,4 +551,19 @@ class tool_policy_api_testcase extends advanced_testcase {
         $this->assertEquals(1, $DB->count_records('tool_policy_acceptances',
             ['userid' => $user2->id, 'policyversionid' => $policy->id]));
     }
+
+    /**
+     * Test that user can login if sitepolicyhandler is set but there are no policies.
+     */
+    public function test_login_with_handler_without_policies() {
+        global $CFG;
+
+        $this->resetAfterTest();
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        $CFG->sitepolicyhandler = 'tool_policy';
+
+        require_login(null, false, null, false, true);
+    }
 }

--- a/tests/behat/managepolicies.feature
+++ b/tests/behat/managepolicies.feature
@@ -40,8 +40,7 @@ Feature: Manage policies
     And I log out
 
   Scenario: Create new policy and save as active
-    When I log in as "admin"
-    # TODO MDL-61844 change to manager!
+    When I log in as "manager"
     And I navigate to "Privacy and policies > Manage policies" in site administration
     And I follow "New policy"
     And I set the following fields to these values:
@@ -153,8 +152,7 @@ Feature: Manage policies
     Given the following policies exist:
       | Name       | Revision | Content    | Summary     | Status   |
       | Policy1    | v1       | full text2 | short text2 | draft    |
-    And I log in as "admin"
-    # TODO MDL-61844 change to manager!
+    And I log in as "manager"
     And I navigate to "Privacy and policies > Manage policies" in site administration
     And I open the action menu in "Policy1" "table_row"
     And I click on "Edit" "link" in the "Policy1" "table_row"
@@ -173,8 +171,7 @@ Feature: Manage policies
     Given the following policies exist:
       | Name       | Revision | Content    | Summary     | Status   |
       | Policy1    | v1       | full text2 | short text2 | draft    |
-    And I log in as "admin"
-    # TODO MDL-61844 change to manager!
+    And I log in as "manager"
     And I navigate to "Privacy and policies > Manage policies" in site administration
     And I open the action menu in "Policy1" "table_row"
     And I click on "Set status to \"Active\"" "link" in the "Policy1" "table_row"


### PR DESCRIPTION
Removed extra-check in the handler to avoid users have to accept new policies during current session (it only happened when there were no policies and policyagreed=0).